### PR TITLE
Add biocViews in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Depends: R (>= 3.2.1), Matrix, igraph
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
+biocViews:
 Imports:
     AnnotationDbi,
     BiocGenerics,
@@ -49,12 +50,6 @@ Suggests:
     rmarkdown,
     uwot
 Remotes: 
-    bioc::release/AnnotationDbi,
-    bioc::release/BiocGenerics,
-    bioc::release/org.Dr.eg.db,
-    bioc::release/org.Hs.eg.db,
-    bioc::release/org.Mm.eg.db,
-    bioc::release/pcaMethods,
     hms-dbmi/sccore
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     rmarkdown,
     uwot
 Remotes: 
-    hms-dbmi/sccore
+    kharchenkolab/sccore
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 LinkingTo: Rcpp, RcppArmadillo, RcppProgress, RcppEigen


### PR DESCRIPTION
* adds `biocViews:` within the `DESCRIPTION`, which is used by devtools to install bioconductor packages
* removes the `bioc::release/*` packages in Remotes, i.e.

```
bioc::release/AnnotationDbi,
bioc::release/BiocGenerics,
bioc::release/org.Dr.eg.db,
bioc::release/org.Hs.eg.db,
bioc::release/org.Mm.eg.db,
bioc::release/pcaMethods,
```

My understanding is that `bioc::` is meant to download the development versions from Bioconductor (which exists in the master branch). I think this was changed to `bioc::release`, but `biocViews` should take care of this, I think. 
