### PR TITLE
remove mapply from factorListToMetadata

### DIFF
--- a/R/pipelineHelpers.R
+++ b/R/pipelineHelpers.R
@@ -111,9 +111,7 @@ factorListToMetadata <- function(factor.list, p2 = NULL) {
       x[rownames(p2$counts)]
     });
   }
-  metadata <- mapply(function(x,n) {
-    p2.metadata.from.factor(x, displayname = n);
-  }, factor.list, names(factor.list), SIMPLIFY = FALSE)
+  metadata <- p2.metadata.from.factor(metadata=factor.list, displayname = names(factor.list))
   invisible(metadata)
 }
 


### PR DESCRIPTION
If I understand this situation correctly, there's some clash between `factorListToMetadata()` and `p2.metadata.from.factor()`. I could be wrong though, so I'll try to explain---perhaps there's a better resolution: 

Motivated by this issue https://github.com/kharchenkolab/pagoda2/issues/42 and the walkthrough, I attempted the following code, which I think should work:

```
library(Matrix)
library(pagoda2)
library(igraph)

cm <- readRDS(file.path(find.package('pagoda2'),'extdata','sample_BM1.rds'))
counts <- gene.vs.molecule.cell.filter(cm,min.cell.size=500)

p2 <- basicP2proc(counts, n.cores = 20)
p2$getKnnClusters(method = igraph::infomap.community, type = 'PCA' ,name = 'infomap', test.stability=T, plot=T)

ext.res <- extendedP2proc(p2, n.cores = 20, organism = 'mm')

p2 <- ext.res$p2
go.env <- ext.res$go.env
rm(ext.res)

metadata.listfactors <- list(
    infomap = p2$clusters$PCA$infomap,
    multilevel = p2$clusters$PCA$multilevel,
    walktrap = p2$clusters$PCA$walktrap
);
metadata.forweb <- factorListToMetadata(metadata.listfactors)
```

I would first get this error
```
> metadata.forweb <- factorListToMetadata(metadata.listfactors)
Error in p2.metadata.from.factor(x, displayname = n) : 
  metadata is not a factor
```

which is an error from `p2.metadata.from.factor()`, i.e.  
https://github.com/kharchenkolab/pagoda2/blob/master/R/pipelineHelpers.R#L268-L276
```
p2.metadata.from.factor <- function(metadata, displayname = NULL, s = 1, v = 1, start = 0, end = NULL, pal = NULL) {
  # Check input
  if ( !is.factor(metadata) ) {
    stop('metadata is not a factor');
  }

  if (  is.null(names(metadata))) {
    stop('metadata needs to be named with cell identifiers');
  }
```

But there's also an error if I try `metadata.forweb <- factorListToMetadata(metadata.listfactors$multilevel)`, whereby `metadata.listfactors$multilevel` is a factor. 

```
> metadata.forweb <-  factorListToMetadata(metadata.listfactors$multilevel)
Error in p2.metadata.from.factor(x, displayname = n) : 
  metadata needs to be named with cell identifiers
```

I think that either `mapply()` statement is erroneous (used in a way when `p2.metadata.from.factor()` was different) or the checks in `p2.metadata.from.factor()` are incorrect. The way it's written now, there will always be an error. Here's using the mapply statement, with `print(x)` and `print(n)` inserted for debugging:

```
> factorListToMetadata(metadata.listfactors$multilevel)
[1] "print x"
[1] 1
Levels: 1 2 3 4 5 6 7 8 9 10
[1] "print n"
[1] "MantonBM1_HiSeq_1-TCTATTGGTCTCTCGT-1"
Error in p2.metadata.from.factor(x, displayname = n) : 
  metadata needs to be named with cell identifiers
```

