### PR TITLE
simply change axes from log10 to log, adjustVariance

### DIFF
--- a/R/Pagoda2.R
+++ b/R/Pagoda2.R
@@ -299,13 +299,13 @@ Pagoda2 <- setRefClass(
         if(do.par) {
           par(mfrow=c(1,2), mar = c(3.5,3.5,2.0,0.5), mgp = c(2,0.65,0), cex = 1.0);
         }
-        smoothScatter(df$m,df$v,main='',xlab='log10[ magnitude ]',ylab='log10[ variance ]')
+        smoothScatter(df$m,df$v,main='',xlab='log[ magnitude ]',ylab='log[ variance ]')
         grid <- seq(min(df$m[vi]),max(df$m[vi]),length.out=1000)
         lines(grid,predict(m,newdata=data.frame(m=grid)),col="blue")
         if(length(ods)>0) {
           points(df$m[ods],df$v[ods],pch='.',col=2,cex=1)
         }
-        smoothScatter(df$m[vi],df$qv[vi],xlab='log10[ magnitude ]',ylab='',main='adjusted')
+        smoothScatter(df$m[vi],df$qv[vi],xlab='log[ magnitude ]',ylab='',main='adjusted')
         abline(h=1,lty=2,col=8)
         if(is.finite(max.adjusted.variance)) { abline(h=max.adjusted.variance,lty=2,col=1) }
         points(df$m[ods],df$qv[ods],col=2,pch='.')


### PR DESCRIPTION
Related to this: https://github.com/kharchenkolab/pagoda2/pull/103

This simply changes the axes from `log10` to `log`. 

The slight problem with this solution is, it's a bit weird, given we just plotted gene counts vs molecule counts in log10:

<img width="842" alt="molecule_gene_log10" src="https://user-images.githubusercontent.com/6968193/90416128-115d8a00-e080-11ea-829e-21f21ed23949.png">

https://github.com/kharchenkolab/pagoda2/blob/master/vignettes/pagoda2.walkthrough.oct2018.md

In any sense, we should chose between either this solution or this: https://github.com/kharchenkolab/pagoda2/pull/103
(and reject one of the PRs)

I never quite realized this would be such a headache when I first started this :)