### PR TITLE
use lambda expression in Hnsw::NormalizeVector

### DIFF
--- a/src/n2/hnsw.cc
+++ b/src/n2/hnsw.cc
@@ -647,7 +647,7 @@ void Hnsw::NormalizeVector(std::vector<float>& vec) {
    float sum = std::inner_product(vec.begin(), vec.end(), vec.begin(), 0.0);
    if (sum != 0.0) {
        sum = 1 / sqrt(sum);
-       std::transform(vec.begin(), vec.end(), vec.begin(), std::bind1st(std::multiplies<float>(), sum));
+       std::transform(vec.begin(), vec.end(), vec.begin(), [sum](float vec){ return vec * sum;});
    }
 }
 


### PR DESCRIPTION
* CRAN complains about `std::bind1st` as it has been deprecated. So, this replaces `std::bind1st` with a lambda expression.
